### PR TITLE
Remove unnecessary installing steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,3 @@ Check out the [issues][issue] and see how you can help out.
 
 [pr]: https://github.com/tryswift/trySwiftAppFinal/pulls
 [issue]: https://github.com/tryswift/trySwiftAppFinal/issues
-
-# To build app
-
-If you don't use [bundler](http://bundler.io/) now, install it to fix cocoapods version in this project.
-
-```
-$ gem install bundler
-```
-
-Then you install gems from Gemfile.
-
-```
-$ bundle install --path vendor/bundle
-```
-
-After you install cocoapods, do `pod install` via bundler:
-
-```
-$ bundle exec pod install
-```


### PR DESCRIPTION
It seems like we don't need to perform the steps to build the app as per the instructions in the Readme. The `/Pods` directory is in the repo, meaning we can run the app "out of the box". Not sure why this was necessary before?