### PR TITLE
Fix controllers not popping when pressing a tab bar button

### DIFF
--- a/trySwift.xcodeproj/project.pbxproj
+++ b/trySwift.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		499CCFF21CC2E0F4007A5BBB /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499CCFF11CC2E0F4007A5BBB /* UIViewControllerExtension.swift */; };
 		49F7B2811E8475F900F09768 /* SplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F7B2801E8475F900F09768 /* SplitViewController.swift */; };
 		4D498DB1B98D4B496FDBB7AA /* Pods_try__Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD2E9D5733A6E1B6E10AFEEF /* Pods_try__Extension.framework */; };
+		5C7F82DB2048B01D009193B4 /* RootTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C7F82DA2048B01D009193B4 /* RootTabBarController.swift */; };
 		7AD1E19C80B78BB08E3DF079 /* Pods_trySwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 620220ABCCCDF47FDAF48B67 /* Pods_trySwift.framework */; };
 		EAFE1C26E49EFABF83487BDC /* Pods_try__Today.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24718BF11477753FCD47A7A8 /* Pods_try__Today.framework */; };
 		FA0E2B4F1E63B90400B40814 /* SessionDetailInterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0E2B4E1E63B90400B40814 /* SessionDetailInterfaceController.swift */; };
@@ -193,6 +194,7 @@
 		499CCFF11CC2E0F4007A5BBB /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
 		49F7B2801E8475F900F09768 /* SplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplitViewController.swift; sourceTree = "<group>"; };
 		58F81AD508535BD405F98215 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		5C7F82DA2048B01D009193B4 /* RootTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabBarController.swift; sourceTree = "<group>"; };
 		5FA07FBC036240AEF8B7C739 /* Pods-trySwift.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-trySwift.release.xcconfig"; path = "Pods/Target Support Files/Pods-trySwift/Pods-trySwift.release.xcconfig"; sourceTree = "<group>"; };
 		620220ABCCCDF47FDAF48B67 /* Pods_trySwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_trySwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C1F9C27BCD8099DCA758F7A /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
@@ -381,6 +383,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		5C7F82D92048B00B009193B4 /* RootTabBar */ = {
+			isa = PBXGroup;
+			children = (
+				5C7F82DA2048B01D009193B4 /* RootTabBarController.swift */,
+			);
+			path = RootTabBar;
+			sourceTree = "<group>";
+		};
 		F413680C9BA29129B4319377 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -415,6 +425,7 @@
 		FA39E8C51C6AB7310074B6BE /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
+				5C7F82D92048B00B009193B4 /* RootTabBar */,
 				FA39E8FB1C6C26150074B6BE /* Schedule */,
 				FA39E9061C6C43480074B6BE /* Speakers */,
 				FABA73BF1D6D9ACE0081D887 /* OfficeHours */,
@@ -1124,6 +1135,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				499BD62A1D05910200E74061 /* Twitter.swift in Sources */,
+				5C7F82DB2048B01D009193B4 /* RootTabBarController.swift in Sources */,
 				FA39E90F1C6C81870074B6BE /* SponsorsViewController.swift in Sources */,
 				FA36B7071E5DA3970022E6A9 /* DateFormatterExtension.swift in Sources */,
 				FAA54F141D9130F900EC9E80 /* UITableViewExtension.swift in Sources */,

--- a/trySwift/Base.lproj/Main.storyboard
+++ b/trySwift/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Tab Bar Controller-->
+        <!--Root Tab Bar Controller-->
         <scene sceneID="mld-K4-cXp">
             <objects>
-                <tabBarController id="Xe8-8h-xaI" sceneMemberID="viewController">
+                <tabBarController id="Xe8-8h-xaI" customClass="RootTabBarController" customModule="trySwift" customModuleProvider="target" sceneMemberID="viewController">
                     <tabBar key="tabBar" contentMode="scaleToFill" id="Iea-je-7kA">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>

--- a/trySwift/RootTabBar/RootTabBarController.swift
+++ b/trySwift/RootTabBar/RootTabBarController.swift
@@ -1,0 +1,25 @@
+//
+//  RootTabBarController.swift
+//  trySwift
+//
+//  Created by Sash Zats on 3/2/18.
+//  Copyright © 2018 NatashaTheRobot. All rights reserved.
+//
+
+import UIKit
+
+class RootTabBarController: UITabBarController, UITabBarControllerDelegate {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.delegate = self
+  }
+
+  func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+    if let splitViewController = viewController as? UISplitViewController {
+      if let navigationController = splitViewController.viewControllers.last as? UINavigationController,
+        navigationController.viewControllers.count > 1 {
+        navigationController.popViewController(animated: true)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This fixes an issue when for some reason (the fact I don't know why bothers me quite a bit) when pressing the tab bar button on the view controller that's already open and drilled down into (for example, Speakers → Particular speaker) normally iOS would pop navigation controller to the root
