### PR TITLE
session and workshop detail images ignore invert color

### DIFF
--- a/trySwift/SessionTableViewCell.swift
+++ b/trySwift/SessionTableViewCell.swift
@@ -26,6 +26,7 @@ class SessionTableViewCell: UITableViewCell {
         super.awakeFromNib()
         
         sessionTitleLabel.textColor = .trySwiftTitleColor()
+        sessionImageView.accessibilityIgnoresInvertColors = true
         sessionTypeLabel.textColor = .trySwiftTitleColor()
         sessionSubtitleLabel.textColor = .trySwiftSubtitleColor()
         sessionLocationLabel.textColor = .trySwiftSubtitleColor()

--- a/trySwift/SpeakerTableViewCell.swift
+++ b/trySwift/SpeakerTableViewCell.swift
@@ -26,6 +26,7 @@ class SpeakerTableViewCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        speakerImageView.accessibilityIgnoresInvertColors = true
         speakerTwitterButton.setTitleColor(.trySwiftAccentColor(), for: .normal)
         speakerImageView.addGestureRecognizer(
           UITapGestureRecognizer(target: self, action: #selector(didTapSpeakerImage))

--- a/trySwift/VenueHeaderTableViewCell.swift
+++ b/trySwift/VenueHeaderTableViewCell.swift
@@ -18,6 +18,7 @@ class VenueHeaderTableViewCell: UITableViewCell {
     
     override func awakeFromNib() {
         super.awakeFromNib()
+        venueImageView.accessibilityIgnoresInvertColors = true
     }
     
     func configure(withVenue venue: Venue) {


### PR DESCRIPTION
Hello!

I have made the speaker images and location images ignore invert color (an accessibility function; see "Display Accommodations" in https://www.apple.com/accessibility/iphone/vision/)

This has been done for the SessionTableViewController and the WorkshopDetailViewController

Thanks to @BasThomas and his awesome acessibility workshop 😁 https://www.tryswift.co/events/2018/nyc/#accessiblity

Sadly I can't attach images; taking screenshots with inverted colors does not work; it saves the photo without colors inverted!

Personally I think it looks nicer 😊