### PR TITLE
Add slack team id to enable opening the correct slack team #39

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   TrySwiftData:
-    :commit: c6153a07790d3b0dda19eb94b2b28438c000df37
+    :commit: 470655bac8fc50b1792a321870dc934fe496063b
     :git: https://github.com/tryswift/trySwiftData.git
 
 SPEC CHECKSUMS:

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -22,7 +22,7 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   TrySwiftData:
-    :commit: c6153a07790d3b0dda19eb94b2b28438c000df37
+    :commit: 470655bac8fc50b1792a321870dc934fe496063b
     :git: https://github.com/tryswift/trySwiftData.git
 
 SPEC CHECKSUMS:

--- a/Pods/TrySwiftData/TrySwiftData/Data/NYC-2018/NYC2018Conferences.swift
+++ b/Pods/TrySwiftData/TrySwiftData/Data/NYC-2018/NYC2018Conferences.swift
@@ -15,6 +15,7 @@ public let nyc2018Conferences: [Conference] = [
         conferenceDescriptionJP: nil,
         email: "nyc@tryswift.co",
         slackURL: "https://tryswiftnyc2018.slack.com/",
+        slackTeamID: "T9Y0ZDK0S",
         venues: [nyc2018Venues["newworldstages"]!, nyc2018Venues["frames"]!],
         organizers: nyc2018Organizers,
         emojiSet: "🐥🎉🗽",

--- a/Pods/TrySwiftData/TrySwiftData/Models/Conference.swift
+++ b/Pods/TrySwiftData/TrySwiftData/Models/Conference.swift
@@ -14,6 +14,7 @@ public struct Conference {
     public let conferenceDescriptionJP: String?
     public let email: String
     public let slackURL: String
+    public let slackTeamID: String
     public let githubIssuesURL = "https://github.com/tryswift/trySwiftAppFinal/issues"
     public let codeOfConductURL = "https://www.tryswift.co/code-of-conduct/"
     public let venues: [Venue]

--- a/trySwift/MoreTableViewController.swift
+++ b/trySwift/MoreTableViewController.swift
@@ -204,7 +204,7 @@ private extension MoreTableViewController {
     
     func openSlack() {
         let application = UIApplication.shared
-        let appURL = URL(string: "slack://open")!
+        let appURL = URL(string: "slack://open?team=\(conference.slackTeamID)")!
         if application.canOpenURL(appURL) {
             application.open(appURL)
         } else {


### PR DESCRIPTION
Open Slack in the correct team #39 

The team ID can be gotten through the browser console under dev-tools as shown here: https://stackoverflow.com/a/44883343